### PR TITLE
Don't bundle to CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,20 +3,10 @@
   "version": "0.1.1",
   "description": "A utility for creating a pan gesture that auto-selects items in a list, like your favorite gallery app.",
   "source": "./src/index.tsx",
-  "main": "./lib/commonjs/index.js",
+  "main": "./lib/module/index.js",
   "module": "./lib/module/index.js",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./lib/typescript/module/src/index.d.ts",
-        "default": "./lib/module/index.js"
-      },
-      "require": {
-        "types": "./lib/typescript/commonjs/src/index.d.ts",
-        "default": "./lib/commonjs/index.js"
-      }
-    }
-  },
+  "exports": "./lib/module/index.js",
+  "types": "./lib/typescript/module/src/index.d.ts",
   "files": [
     "src",
     "lib",
@@ -143,12 +133,6 @@
     "source": "src",
     "output": "lib",
     "targets": [
-      [
-        "commonjs",
-        {
-          "esm": true
-        }
-      ],
       [
         "module",
         {


### PR DESCRIPTION
The package is currently broken as all worklets are not workletized.

It seems there's a problem somewhere where when exporting CJS code, Reanimated's babel plugin will not process worklets defined using the `function` keyword. They must be defined as arrow functions before compiling to CJS.

Rather than do that, I'm skipping bundling CJS for now and making ESM the default especially since we don't support web.