### PR TITLE
[breaking]: Add support for performing only continuous selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ interface Config<ListItem = unknown> {
      */
     endMaxVelocity?: number
   }
+  tapGesture?: {
+    /**
+     * Whether tapping an item while selection mode is active should add or remove it from selection.
+     * @default true
+     */
+    selectOnTapEnabled: boolean
+  }
   /**
    * Invoked on the JS thread whenever an item is tapped, but not added to selection.
    * You may still wrap items with your own pressable component while using this callback to handle the press event.

--- a/dev/src/Horizontal.tsx
+++ b/dev/src/Horizontal.tsx
@@ -56,7 +56,7 @@ export function HorizontalList() {
       },
       horizontal: true,
     },
-    panScrollGesture: { enabled: false },
+    panGesture: { enabled: false },
     onItemPress: (id) => {
       console.log("onItemPress", id)
     },

--- a/dev/src/Vertical.tsx
+++ b/dev/src/Vertical.tsx
@@ -58,7 +58,7 @@ export function VerticalList() {
         right: paddingHorizontal,
       },
     },
-    panScrollGesture: { enabled: false },
+    panGesture: { enabled: false },
     onItemPress: (id) => {
       console.log("onItemPress", id)
     },

--- a/example/app/gallery.tsx
+++ b/example/app/gallery.tsx
@@ -63,9 +63,9 @@ export default function List() {
         bottom: bottomPadding,
       },
     },
-    panScrollGesture: {
+    panGesture: {
       enabled: Platform.OS === "ios",
-      endThreshold: 0.65,
+      scrollEndThreshold: 0.65,
     },
     onItemPress: (id, index) => {
       console.log("onItemPress", { id, index })

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,24 +95,29 @@ export interface Config<ListItem = unknown> {
    * Configuration for automatic scrolling.
    * This occurs when panning near scrolling edges of the list.
    */
-  panScrollGesture?: {
+  panGesture?: {
+    /**
+     * When `true`, selection is cleared each time the pan gesture starts again.
+     * @default false
+     */
+    resetSelectionOnStart?: boolean
     /**
      * Whether automatic scrolling is enabled.
      * @default true
      */
-    enabled?: boolean
+    scrollEnabled?: boolean
     /**
      * How close should the pointer be to the start of the list before **inverse** scrolling begins.
      * A value between 0 and 1 where 1 is equal to the height of the list window.
      * @default 0.15
      */
-    startThreshold?: number
+    scrollStartThreshold?: number
     /**
      * How close should the pointer be to the end of the list before scrolling begins.
      * A value between 0 and 1 where 1 is equal to the height of the list window.
      * @default 0.85
      */
-    endThreshold?: number
+    scrollEndThreshold?: number
     /**
      * The maximum scrolling speed when the pointer is near the starting edge of the list window.
      * Must be higher than 0.
@@ -120,7 +125,7 @@ export interface Config<ListItem = unknown> {
      *  - 8 on iOS
      *  - 1 on Android
      */
-    startMaxVelocity?: number
+    scrollStartMaxVelocity?: number
     /**
      * The maximum scrolling speed when the pointer is at the ending edge of the list window.
      * Must be higher than 0.
@@ -128,7 +133,14 @@ export interface Config<ListItem = unknown> {
      *  - 8 on iOS
      *  - 1 on Android
      */
-    endMaxVelocity?: number
+    scrollEndMaxVelocity?: number
+  }
+  tapGesture?: {
+    /**
+     * Whether tapping an item while selection mode is active should add or remove it from selection.
+     * @default true
+     */
+    selectOnTapEnabled: boolean
   }
   /**
    * Invoked on the JS thread whenever an item is tapped, but not added to selection.
@@ -169,7 +181,7 @@ export interface DragSelect {
     createItemPressHandler: (id: string, index: number) => SimultaneousGesture
     /**
      * This is a single [pan gesture](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture).
-     * If you need to rely solely on pressing items for selection, you can disable the pan gesture by setting `config.panScrollGesture.enabled` to `false`. See {@link Config.panScrollGesture}.
+     * If you need to rely solely on pressing items for selection, you can disable the pan gesture by setting `config.panScrollGesture.enabled` to `false`. See {@link Config.panGesture}.
      *
      * Do not customize the behavior of this gesture directly.
      * Instead, [compose](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/composed-gestures) it with your own.


### PR DESCRIPTION
For example, when selecting a continuous date range it will be useful to disallow selecting random items by tapping or panning.

This renames options in the config which is a breaking change.