### PR TITLE
Improve long-press activation reliability for small list items

### DIFF
--- a/src/useDragSelect.tsx
+++ b/src/useDragSelect.tsx
@@ -512,9 +512,10 @@ export function useDragSelect<ListItem extends Record<string, any>>(
     "worklet"
     const index = itemIndexById.value.get(id)
     if (index === undefined) return
+    axisItem.value = { id, index }
+
     const inSelection = selectedItemMap.value[id]
     if (inSelection !== undefined) return
-    axisItem.value = { id, index }
     select(id)
   }
 
@@ -554,11 +555,13 @@ export function useDragSelect<ListItem extends Record<string, any>>(
           }
         })
         .onEnd(() => {
+          axisItem.value = null
           panTransitionFromIndex.value = null
           panEvent.value = null
           runOnJS(setFrameCbActive)(false)
         }),
     [
+      axisItem,
       longPressMinDurationMs,
       measureListLayout,
       panEvent,
@@ -582,6 +585,8 @@ export function useDragSelect<ListItem extends Record<string, any>>(
       .onStart(() => longPressOnStart(id))
       .simultaneousWithExternalGesture(panHandler)
       .enabled(longPressGestureEnabled)
+      .numberOfPointers(1)
+      .maxDistance(50)
 
     return Gesture.Simultaneous(tapGesture, longPressGesture)
   }


### PR DESCRIPTION
- For smaller items, it's better to have a largeer `maxDistance` as the finger can travel to prevent the gesture from easily getting canceled. It seems harmless to use this value as the default.
- Max pointers set to 1. I assume this is the default anyway.
- Clear axis at the end of panning, since a new axis should be assigned at the start of the next pan.


**Note:**

We're currently relying on the long press gesture to assign the pan axis, but we should determine the axis using the `onStart` event of the pan gesture instead.

This also would allow iOS style drag-to-select without a long press required.